### PR TITLE
Blade deploy rewrite

### DIFF
--- a/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
@@ -16,56 +16,42 @@ all projects in a folder by running the `deploy` command from the parent folder
 
 If you're using Liferay Workspace, the `deploy` command copies your project to
 the @product@ `/deploy` folder, which is found by reading the Liferay Home
-folder set in your workspace's `gradle.properties` file (i.e.,
-`liferay.workspace.home.dir`). The `deploy` command works similarly if you're
-working outside of workspace; the Liferay Home folder, in contrast, is set by
-loading the Liferay extension object (Gradle) or the effective POM (Maven) and
-searching for the Liferay Home property stored there. If it's not stored, Blade
-prompts you to set it so it's available.
+folder set in your workspace's `gradle.properties` or `pom.xml` file. The
+`deploy` command works similarly if you're working outside of workspace; the
+Liferay Home folder, in contrast, is set by loading the Liferay extension object
+(Gradle) or the effective POM (Maven) and searching for the Liferay Home
+property stored there. If it's not stored, Blade prompts you to set it so it's
+available.
 
-<!-- Above paragraph is explained based on how it was described BEFORE
-development (BLADE-361). Follow up and update as necessary. -Cody -->
++$$$
 
-<!-- Gradle:
+**Note:**
 
-Assuming the `com.liferay.plugin` is applied, this can be done by adding the
-following snippet inside the Gradle project's `build.gradle` file:
+If you prefer using pure Gradle or Maven to deploy your project, you can do this
+by applying the appropriate plugin and configuring your Liferay Home property.
+Here's how you can do this for Gradle and Maven:
+
+**Gradle:**
+
+First ensure the Liferay Gradle plugin is applied in your `build.gradle` file:
+
+    apply plugin: "com.liferay.plugin"
+
+Then extend the Liferay extension object to set your Liferay Home and `deploy`
+folder:
 
     liferay {
         liferayHome = "../../../../liferay-ce-portal-7.1.1-ga2"
         deployDir = file("${liferayHome}/deploy")
     }
--->
 
-<!-- Maven:
+**Maven:**
 
-TBD
-
--->
-
-+$$$
-
-**Note:** The `blade deploy` command requires a Gradle/Maven wrapper to
-successfully execute. To ensure the availability of a build tool wrapper, work
-in a Liferay Workspace. For more information on Liferay Workspaces, see the
-[Creating a Liferay Workspace with Blade CLI](/develop/tutorials/-/knowledge_base/7-1/creating-a-liferay-workspace-with-blade-cli)
-tutorial.
+Ensure the Bundle Support plugin is applied and configure Liferay Home in your
+`pom.xml`. See the
+[Deploying a Project Built with Maven to Liferay Portal](/tutorials/-/knowledge_base/7-1/deploying-a-project-built-with-maven-to-product)
+for details.
 
 $$$
-
-+$$$
-
-**Note:** If you run into errors during the build/deploy process of your
-project, check to make sure your workspace is accounting for the
-[appropriate certificates](/develop/tutorials/-/knowledge_base/7-1/configuring-a-liferay-workspace#certification-issues-in-liferay-workspace).
-
-$$$
-
-You can also watch the deployed module for changes by specifying the `-w`
-parameter.
-
-    blade deploy -w
-
-This parameter automatically redeploys the module when changes are detected.
 
 Cool! You've successfully deployed your module project using Blade CLI.

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
@@ -26,6 +26,23 @@ prompts you to set it so it's available.
 <!-- Above paragraph is explained based on how it was described BEFORE
 development (BLADE-361). Follow up and update as necessary. -Cody -->
 
+<!-- Gradle:
+
+Assuming the `com.liferay.plugin` is applied, this can be done by adding the
+following snippet inside the Gradle project's `build.gradle` file:
+
+    liferay {
+        liferayHome = "../../../../liferay-ce-portal-7.1.1-ga2"
+        deployDir = file("${liferayHome}/deploy")
+    }
+-->
+
+<!-- Maven:
+
+TBD
+
+-->
+
 +$$$
 
 **Note:** The `blade deploy` command requires a Gradle/Maven wrapper to

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/05-deploying-projects-with-blade-cli.markdown
@@ -5,8 +5,8 @@ the Blade `deploy` command, you must first have built a project to deploy. See
 the
 [Creating Projects with Blade CLI](/develop/tutorials/-/knowledge_base/7-1/creating-projects-with-blade-cli)
 tutorials for more information about creating Liferay projects. Once you've
-built a project, navigate to it in your terminal window and execute the following
-command to deploy it:
+built a project, navigate to it with your CLI and execute the following command
+to deploy it:
 
     blade deploy
 
@@ -14,35 +14,35 @@ This can be used for WAR-style projects and modules (JARs). You can also deploy
 all projects in a folder by running the `deploy` command from the parent folder
 (e.g., `[WORKSPACE_ROOT]/modules`).
 
-When deploying a project using Blade CLI, the project is directly installed into
-the OSGi container. This means, for example, that a deployed module isn't stored
-in the `LIFERAY_HOME/osgi/modules` folder; only modules copied to the
-`LIFERAY_HOME/deploy` folder (i.e., leveraging the auto deployment mechanism)
-are stored there. A module deployed by Blade CLI is stored only as bytecode in
-`LIFERAY_HOME/osgi/state/org.eclipse.osgi` in a subfolder named after its bundle
-ID. All modules installed in OSGi's registry are stored this way, even those
-copied to the `/deploy` folder. Visit the 
-[Using the Felix Gogo Shell](/develop/reference/-/knowledge_base/7-1/using-the-felix-gogo-shell)
-article for instructions on finding a bundle's ID.
+If you're using Liferay Workspace, the `deploy` command copies your project to
+the @product@ `/deploy` folder, which is found by reading the Liferay Home
+folder set in your workspace's `gradle.properties` file (i.e.,
+`liferay.workspace.home.dir`). The `deploy` command works similarly if you're
+working outside of workspace; the Liferay Home folder, in contrast, is set by
+loading the Liferay extension object (Gradle) or the effective POM (Maven) and
+searching for the Liferay Home property stored there. If it's not stored, Blade
+prompts you to set it so it's available.
 
-If you run into errors during the build/deploy process of your project, check to
-make sure your workspace is accounting for the
+<!-- Above paragraph is explained based on how it was described BEFORE
+development (BLADE-361). Follow up and update as necessary. -Cody -->
+
++$$$
+
+**Note:** The `blade deploy` command requires a Gradle/Maven wrapper to
+successfully execute. To ensure the availability of a build tool wrapper, work
+in a Liferay Workspace. For more information on Liferay Workspaces, see the
+[Creating a Liferay Workspace with Blade CLI](/develop/tutorials/-/knowledge_base/7-1/creating-a-liferay-workspace-with-blade-cli)
+tutorial.
+
+$$$
+
++$$$
+
+**Note:** If you run into errors during the build/deploy process of your
+project, check to make sure your workspace is accounting for the
 [appropriate certificates](/develop/tutorials/-/knowledge_base/7-1/configuring-a-liferay-workspace#certification-issues-in-liferay-workspace).
 
-Blade CLI can detect a locally running Liferay instance and automatically
-deploys your project to that Liferay instance. Blade communicates with the OSGi
-framework using Felix Gogo shell and deploys the project directly to the OSGi
-container using Felix File Install commands. The command uses the default
-`11311` port by default.
-
-<!--
-You can also specify a custom port to deploy your module to using the `-p`
-parameter followed by the port number. For instance, you could run `blade deploy
--p 8090` to deploy to port 8090.
--->
-
-<!-- Follow BLADE-189 for info on supporting host and port commands for Blade
-deployment. -Cody -->
+$$$
 
 You can also watch the deployed module for changes by specifying the `-w`
 parameter.
@@ -50,16 +50,5 @@ parameter.
     blade deploy -w
 
 This parameter automatically redeploys the module when changes are detected.
-
-+$$$
-
-**Note:** The `blade deploy` command requires a Gradle/Maven wrapper to
-successfully execute. To ensure the availability of a build tool wrapper, be
-sure to work in a Liferay Workspace. For more information on Liferay Workspaces,
-see the
-[Creating a Liferay Workspace with Blade CLI](/develop/tutorials/-/knowledge_base/7-1/creating-a-liferay-workspace-with-blade-cli)
-tutorial.
-
-$$$
 
 Cool! You've successfully deployed your module project using Blade CLI.


### PR DESCRIPTION
Can you review this rewrite for our `blade deploy` docs? They're pretty straightforward, but I made some assumptions based on the ticket and what I've heard about it.

I also included a note for ways to deploy Liferay projects with pure Gradle and Maven (outside of workspace).